### PR TITLE
DM-26565: Make the endpoint manager handle empty files better

### DIFF
--- a/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
@@ -132,9 +132,11 @@ class Finder(object):
                     logger.error(f"{abspath}: no such file")
                     logger.debug(f"terminating processing of '{abspath}'")
                     continue
+                filename = os.path.basename(relpath)
                 try:
                     records = self.session.query(self.File).\
-                        filter(self.File.checksum == checksum).all()
+                        filter(self.File.checksum == checksum,
+                               self.File.filename == filename).all()
                 except SQLAlchemyError as ex:
                     logger.error(f"cannot check for duplicates: {ex}")
                     logger.debug(f"terminating processing of '{abspath}'")

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
@@ -145,7 +145,7 @@ class Finder(object):
                     dups = ", ".join(str(rec.id) for rec in records)
                     logger.error(f"file '{abspath}' already in the "
                                  f"storage area '{self.storage}: "
-                                 f"(see row(s): {dups}), removing")
+                                 f"(see row(s): {dups})")
                     action_type = "alt"
 
                 action = self.dispatch[action_type]


### PR DESCRIPTION
Empty files were not handled optimally by the endpoint manager. Firstly, all empty files, except the one which was discovered first, were treated as duplicates and deleted.  Secondly, the manager still tried to ingest the empty file to the database system. It was causing rather obscure errors coming from the ingest software being recorded as the reason behind the failure.  To handle such files better, I slightly altered the logic which tells Finder if a file is a duplicate or not and prevented Ingester from making ingest attempts for empty files.  Now it creates an entry of a failed attempt with a clear message about file being empty.