### PR TITLE
DM-26646: Make endpoint manager monitor future day(s)

### DIFF
--- a/etc/finder.yaml
+++ b/etc/finder.yaml
@@ -14,7 +14,8 @@ finder:
     method: scan
     blacklist: null
     date: null
-    timespan: 1
+    past_days: 1
+    future_days: 1
   pause: 1
 logging:
   file: null

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
@@ -287,10 +287,10 @@ def parse_rsync_logs(directory, blacklist=None,
         List of regular expressions file names should be match against. If a
         filename matches any of the patterns in the list, file will be ignored.
         By default, no file is ignored.
-    isodate : `datetime.date`, optional
-        A date corresponding the directory which the function should
-        monitor for new logs. If None (default), it will be set to the
-        current date.
+    isodate : `str`, optional
+        String representing ISO date corresponding the directory which the
+        function should monitor for new logs. If None (default), it will be set
+        to the current date.
     past_days : `int`, optional
         The number of past days to add to the list of monitored directories.
         Defaults to 1.
@@ -313,10 +313,10 @@ def parse_rsync_logs(directory, blacklist=None,
     delay = timedelta(seconds=delay)
     origin = date.today()
     if isodate is not None:
-        origin = isodate
-    past = [origin - timedelta(days=n) for n in range(1, past_days+1)]
-    future = [origin + timedelta(days=n) for n in range(1, future_days+1)]
-    for day in sorted([*past, origin, *future]):
+        origin = date.fromisoformat(isodate)
+    start = origin - timedelta(days=past_days)
+    for offset in range(past_days + future_days + 1):
+        day = start + timedelta(days=offset)
         top = os.path.join(directory, day.isoformat().replace("-", ""))
         if not os.path.exists(top):
             continue

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
@@ -274,10 +274,13 @@ def parse_rsync_logs(directory, blacklist=None,
     from parsing the file again.
 
     As the files from a single observation night can be placed in different
-    directories and these directories can be created in a time zone different
-    from the one the endpoint site operates in, be default the function
-    monitors also log files in directories corresponding to a day before and
-    a day after the current day (if any of them exists).
+    directories and these directories can be created in a time zone
+    different from the one the endpoint site operates in, be default the
+    function monitors also log files in directories corresponding to a day
+    before and a day after the current day (if any of them exists).  This
+    default settings determining which directories will be monitored can be
+    changed by adjusting ``past_days`` and ``future_days`` options (see
+    below).
 
     Parameters
     ----------

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
@@ -108,7 +108,8 @@ class Finder:
             raise ValueError(msg)
         self.search_opts = dict(blacklist=search.get("blacklist", None),
                                 isodate=search.get("date", None),
-                                timespan=search.get("timespan", 1),
+                                past_days=search.get("past_days", 1),
+                                future_days=search.get("future_days", 1),
                                 delay=search.get("delay", 60))
 
         # If we are monitoring rsync transfers, files are already in the
@@ -253,14 +254,13 @@ def scan(directory, blacklist=None, **kwargs):
 
 
 def parse_rsync_logs(directory, blacklist=None,
-                     isodate=None, timespan=1, delay=60, extension="done"):
+                     isodate=None, past_days=1, future_days=1,
+                     delay=60, extension="done"):
     """Generate the file names based on the content of the rsync logs.
 
     This is a specialized search method for finding files which where
     transferred to the storage area by ``rsync``. It identifies these
-    files by parsing log files created by it.
-
-    It assumes that:
+    files by parsing ``rsync``'s log files. It assumes that:
 
     1. The logs are stored in a centralized location.
     2. Logs from different days are kept in different subdirectories in that
@@ -272,6 +272,12 @@ def parse_rsync_logs(directory, blacklist=None,
     After the function completed parsing a given logfile, it creates an
     empty file ``<logfile>.<extension>`` which act as a sentinel preventing it
     from parsing the file again.
+
+    As the files from a single observation night can be placed in different
+    directories and these directories can be created in a time zone different
+    from the one the endpoint site operates in, be default the function
+    monitors also log files in directories corresponding to a day before and
+    a day after the current day (if any of them exists).
 
     Parameters
     ----------
@@ -285,11 +291,12 @@ def parse_rsync_logs(directory, blacklist=None,
         A date corresponding the directory which the function should
         monitor for new logs. If None (default), it will be set to the
         current date.
-    timespan : `int`, optional
-        The number of previous days to add to the list of monitored
-        directories. Defaults to 1 which means that the function will
-        monitor log files in a subdirectory corresponding to whatever day
-        the``isodate`` was set to and the day before (if it exists).
+    past_days : `int`, optional
+        The number of past days to add to the list of monitored directories.
+        Defaults to 1.
+    future_days : `int`, optional
+        The number of future days to add to the list of monitored directories.
+        Defaults to 1.
     delay : `int`, optional
         Time (in seconds) that need to pass from log's last modification before
         it will be considered fully transferred. By default, it is 60 s.
@@ -304,11 +311,12 @@ def parse_rsync_logs(directory, blacklist=None,
     if blacklist is None:
         blacklist = []
     delay = timedelta(seconds=delay)
-    end = date.today()
+    origin = date.today()
     if isodate is not None:
-        end = isodate
-    dates = [end - timedelta(days=n) for n in range(timespan+1)]
-    for day in dates:
+        origin = isodate
+    past = [origin - timedelta(days=n) for n in range(1, past_days+1)]
+    future = [origin + timedelta(days=n) for n in range(1, future_days+1)]
+    for day in sorted([*past, origin, *future]):
         top = os.path.join(directory, day.isoformat().replace("-", ""))
         if not os.path.exists(top):
             continue

--- a/python/lsst/dbb/buffmngrs/endpoint/validation.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/validation.py
@@ -64,6 +64,7 @@ properties:
                               enum:
                                 - Delete
                                 - Move
+                                - Noop
                             - type: "null"
                     alternative:
                         anyOf:
@@ -71,6 +72,7 @@ properties:
                               enum:
                                 - Delete
                                 - Move
+                                - Noop
                             - type: "null"
             search:
                 type: object
@@ -89,8 +91,15 @@ properties:
                     date:
                         anyOf:
                             - type: string
+                              format: date
                             - type: "null"
-                    timespan:
+                    past_days:
+                        type: integer
+                        minimum: 0
+                    future_days:
+                        type: integer
+                        minimum: 0
+                    delay:
                         type: integer
                         minimum: 0
                 required:
@@ -137,6 +146,22 @@ properties:
     ingester:
         type: object
         properties:
+            storage:
+                type: string
+            blacklist:
+                anyOf:
+                    - type: array
+                      items:
+                         type: string
+                      uniqueItems: true
+                    - type: "null"
+            whitelist:
+                anyOf:
+                    - type: array
+                      items:
+                         type: string
+                      uniqueItems: true
+                    - type: "null"
             plugin:
                 type: object
                 properties:
@@ -195,6 +220,7 @@ properties:
                 type: integer
                 minimum: 0
         required:
+            - storage
             - plugin
     logging:
         type: object


### PR DESCRIPTION
Files from a single observation night can be placed in different directories and these directories can be created in a time zone
different from the one the endpoint site operates in.  Though the endpoint manager was already able to monitor past days, it is not able to look "into the future" which may be required for some time zones.  To address this issue I added an option to the search function parsing rsync logs which will allow one to instruct the manager to "look ahead" of local time for a given number of days (1, by default).