### PR TITLE
DM-28035: Backfill tool for DBB endpoint manager (Stage 1)

### DIFF
--- a/doc/lsst.dbb.buffmngrs.endpoint/get-started.rst
+++ b/doc/lsst.dbb.buffmngrs.endpoint/get-started.rst
@@ -269,13 +269,13 @@ tell the Ingester to make another ingest attempt for selected files.  To do so:
             table: files
           event:
             table: gen2_file_events
-        ingester:
-          plugin:
-            name: Gen2Ingest
-            config:
-              root: /data/gen2repo
-          daemon: false
-          file_status: RERUN
+      ingester:
+        plugin:
+          name: Gen2Ingest
+          config:
+            root: /data/gen2repo
+        daemon: false
+        file_status: RERUN
 
 When run in non-daemonic mode, the Ingester will quit after processing all the
 files with ``RERUN`` status.

--- a/etc/backfill.yaml
+++ b/etc/backfill.yaml
@@ -3,7 +3,7 @@ database:
   tablenames:
     file:
       schema: null
-      tablename: loc_inst_files
+      table: loc_inst_files
     event:
       schema: null
       table: loc_inst_gen2_file_events

--- a/etc/backfill.yaml
+++ b/etc/backfill.yaml
@@ -1,0 +1,21 @@
+database:
+  engine: "postgres://tester:password@localhost:5432/test"
+  tablenames:
+    file:
+      schema: null
+      tablename: loc_inst_files
+    event:
+      schema: null
+      table: loc_inst_gen2_file_events
+  echo: false
+  pool_class: QueuePool
+backfill:
+  storage: /data/storage
+  sources:
+    - "subdir"
+  search:
+    blacklist: null
+logging:
+  file: null
+  format: "%(asctime)s:%(name)s:%(levelname)s:%(message)s"
+  level: INFO

--- a/etc/finder.yaml
+++ b/etc/finder.yaml
@@ -3,7 +3,7 @@ database:
   tablenames:
     file:
       schema: null
-      file: loc_inst_files
+      table: loc_inst_files
   echo: false
   pool_class: QueuePool
 finder:

--- a/etc/finder.yaml
+++ b/etc/finder.yaml
@@ -1,8 +1,9 @@
 database:
   engine: "postgres://tester:password@localhost:5432/test"
   tablenames:
-    schema: null
-    file: loc_inst_files
+    file:
+      schema: null
+      file: loc_inst_files
   echo: false
   pool_class: QueuePool
 finder:

--- a/etc/gen2ingester.yaml
+++ b/etc/gen2ingester.yaml
@@ -10,6 +10,7 @@ database:
   echo: false
   pool_class: QueuePool
 ingester:
+  storage: /data/storage
   plugin:
     name: Gen2Ingest
 

--- a/etc/gen3ingester.yaml
+++ b/etc/gen3ingester.yaml
@@ -10,6 +10,7 @@ database:
   echo: false
   pool_class: QueuePool
 ingester:
+  storage: /data/storage
   plugin:
     name: Gen3Ingest
     config:

--- a/python/lsst/dbb/buffmngrs/endpoint/backfill/backfill.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/backfill/backfill.py
@@ -38,7 +38,7 @@ __all__ = ["Backfill"]
 logger = logging.getLogger(__name__)
 
 
-class Backfill(object):
+class Backfill:
     """A backfill tool allowing one to deal with historical files.
 
     It creates database entries for historical files, i.e., files which were

--- a/python/lsst/dbb/buffmngrs/endpoint/backfill/backfill.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/backfill/backfill.py
@@ -1,0 +1,175 @@
+# This file is part of dbb_buffmngrs_endpoint.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Component responsible for backfilling historical files.
+"""
+import datetime
+import logging
+import os
+from glob import glob
+from itertools import chain
+from sqlalchemy.exc import SQLAlchemyError
+from ..declaratives import event_creator, file_creator
+from ..search import scan
+from ..status import Status
+from ..utils import get_checksum
+
+
+__all__ = ["Backfill"]
+
+
+logger = logging.getLogger(__name__)
+
+
+class Backfill(object):
+    """A backfill tool allowing one to deal with historical files.
+
+    It creates database entries for historical files, i.e., files which were
+    present in the storage area *before* the DBB endpoint manager was
+    deployed.
+
+    The status of backfilled files is set to ``BACKFILL``.
+
+    At the moment, it does *not* verify if any historical file it creates
+    entries for was actually successfully ingested to a Butler repository.
+
+    Parameters
+    ----------
+    config : `dict`
+        Backfill configuration.
+
+    Raises
+    ------
+    ValueError
+        If a required setting is missing.
+    """
+
+    def __init__(self, config):
+        # Check if configuration is valid, i.e., all required settings are
+        # provided; complain if not.
+        required = {"session", "sources", "storage", "tablenames"}
+        missing = required - set(config)
+        if missing:
+            msg = f"invalid configuration: {', '.join(missing)} not provided"
+            logger.error(msg)
+            raise ValueError(msg)
+
+        self.session = config["session"]
+
+        required = {"event", "file"}
+        missing = required - set(config["tablenames"])
+        if missing:
+            msg = f"invalid ORMs: {', '.join(missing)} not provided"
+            logger.error(msg)
+            raise ValueError(msg)
+        self.Event = event_creator(config["tablenames"])
+        self.File = file_creator(config["tablenames"])
+
+        self.storage = os.path.abspath(config["storage"])
+        if not os.path.isdir(self.storage):
+            msg = f"directory '{self.storage}' not found"
+            logger.error(msg)
+            raise ValueError(msg)
+        self.sources = config["sources"]
+
+        search = config["search"]
+        self.search_opts = dict(blacklist=search.get("blacklist", None))
+
+    def run(self):
+        """Start the backfill process.
+        """
+        sources = [glob(os.path.join(self.storage, s)) for s in self.sources]
+        for source in chain(*sources):
+            if not os.path.exists(source):
+                logger.warning(f"{source}: no such file or directory")
+                continue
+
+            paths = scan(source, **self.search_opts) if os.path.isdir(source) \
+                else [source]
+            for path in paths:
+                abspath = os.path.join(source, path)
+                relpath = os.path.relpath(abspath, start=self.storage)
+                dirname, filename = os.path.split(relpath)
+                logger.debug(f"{relpath}: starting processing")
+
+                logger.debug(f"checking if already tracked")
+                try:
+                    record = self.session.query(self.File). \
+                        filter(self.File.relpath == dirname,
+                               self.File.filename == filename).first()
+                except SQLAlchemyError as ex:
+                    logger.error(f"{relpath}: cannot check if tracked: {ex}")
+                    logger.debug(f"{relpath}: terminating processing")
+                    continue
+                if record is not None:
+                    logger.warning(f"file already tracked (id: {record.id})")
+                    logger.debug(f"{relpath}: terminating processing")
+                    continue
+
+                logger.debug(f"calculating checksum")
+                try:
+                    checksum = get_checksum(abspath)
+                except FileNotFoundError:
+                    logger.error(f"{relpath}: no such file")
+                    logger.debug(f"{relpath}: terminating processing")
+                    continue
+
+                # Always make BOTH inserts in a single transaction!
+                # Otherwise new entry in file table may be picked up by
+                # an Ingester daemon running in the background.
+                logger.debug(f"updating database entries")
+
+                # Add file record (starts the transaction).
+                entry = self.File(
+                    relpath=dirname,
+                    filename=filename,
+                    checksum=checksum,
+                )
+                self.session.add(entry)
+
+                # Query the database to find out the id which was assigned
+                # to that record.
+                try:
+                    (id_,) = self.session.query(self.File.id). \
+                        filter(self.File.checksum == checksum)
+                except SQLAlchemyError as ex:
+                    self.session.rollback()
+                    logger.error(f"{relpath}: cannot query the database: {ex}")
+                    logger.debug(f"{relpath}: terminating processing")
+                    continue
+
+                # Add the corresponding event record.
+                entry = self.Event(
+                    status=Status.BACKFILL.value,
+                    start_time=datetime.datetime.now(),
+                    files_id=id_,
+                )
+                self.session.add(entry)
+
+                # Finally, commit the changes or roll the changes back if
+                # any errors were encountered (ends the transaction).
+                try:
+                    self.session.commit()
+                except Exception as ex:
+                    self.session.rollback()
+                    logger.error(f"{relpath}: creating database entries "
+                                 f"failed: {ex}")
+                else:
+                    logger.debug(f"{relpath}: processing completed")

--- a/python/lsst/dbb/buffmngrs/endpoint/backfill/backfill.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/backfill/backfill.py
@@ -112,7 +112,7 @@ class Backfill:
                 dirname, filename = os.path.split(relpath)
                 logger.debug(f"{relpath}: starting processing")
 
-                logger.debug(f"checking if already tracked")
+                logger.debug("checking if already tracked")
                 try:
                     record = self.session.query(self.File). \
                         filter(self.File.relpath == dirname,
@@ -134,13 +134,13 @@ class Backfill:
                 except FileNotFoundError:
                     logger.error(f"{relpath}: no such file")
                     logger.debug(f"{relpath}: terminating processing")
-                    acc["failure"] += 1
+                    counts["notfound"] += 1
                     continue
 
                 # Always make BOTH inserts in a single transaction!
                 # Otherwise new entry in file table may be picked up by
                 # an Ingester daemon running in the background.
-                logger.debug(f"updating database entries")
+                logger.debug("updating database entries")
 
                 # Add file record (starts the transaction).
                 file = self.File(

--- a/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
@@ -62,7 +62,7 @@ def start(filename, dump, validate):
     with open(filename) as f:
         configuration = yaml.safe_load(f)
     if validate:
-        schema = yaml.safe_load(validation.backfill)
+        schema = yaml.safe_load(validation.BACKFILL)
         try:
             jsonschema.validate(instance=configuration, schema=schema)
         except jsonschema.ValidationError as ex:

--- a/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
@@ -20,11 +20,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Command line interface for the Backfill component.
 """
-import click
 import importlib
 import inspect
 import jsonschema
 import logging
+import click
 import yaml
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker

--- a/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
@@ -1,0 +1,139 @@
+# This file is part of dbb_buffmngrs_endpoint.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Command line interface for the Backfill component.
+"""
+import click
+import importlib
+import inspect
+import jsonschema
+import logging
+import yaml
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+from .backfill import Backfill
+from .. import validation
+from ..utils import (
+    dump_config,
+    dump_env,
+    setup_logging,
+    find_missing_tables,
+    fully_qualify_tables,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+def backfill():
+    """Populate the database with entries for historical files.
+    """
+    pass
+
+
+@backfill.command()
+@click.option("--dump/--no-dump", default=True,
+              help="Log runtime environment and configuration "
+                   "(ignored if severity is set to WARNING and higher).")
+@click.option("--validate/--no-validate", default=False,
+              help="Validate configuration before starting the service.")
+@click.argument("filename", type=click.Path(exists=True))
+def start(filename, dump, validate):
+    """Starts a finder using a configuration from FILENAME.
+    """
+    with open(filename) as f:
+        configuration = yaml.safe_load(f)
+    if validate:
+        schema = yaml.safe_load(validation.finder)
+        try:
+            jsonschema.validate(instance=configuration, schema=schema)
+        except jsonschema.ValidationError as ex:
+            msg = f"configuration error: {ex.message}."
+            logger.error(msg)
+            raise ValueError(msg)
+        except jsonschema.SchemaError as ex:
+            msg = f"schema error: {ex.message}."
+            logger.error(msg)
+            raise ValueError(msg)
+        return
+
+    config = configuration.get("logging", None)
+    setup_logging(options=config)
+
+    if dump:
+        msg = "runtime environment and configuration:\n\n"
+        msg += dump_env()
+        msg += "\n"
+        msg += dump_config(configuration)
+        logger.info(msg)
+
+    logger.info("setting up database connection...")
+    config = configuration["database"]
+
+    module = importlib.import_module("sqlalchemy.pool")
+    pool_name = config.get("pool_class", "QueuePool")
+    try:
+        class_ = getattr(module, pool_name)
+    except AttributeError:
+        msg = f"unknown connection pool type: {pool_name}"
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+    engine = create_engine(config["engine"],
+                           echo=config.get("echo", False),
+                           poolclass=class_)
+    insp = inspect(engine)
+
+    # Save tablenames for future reference making sure the schema is always
+    # explicitly specified (needed to properly define ORMs later on).
+    tablenames = fully_qualify_tables(insp, dict(config["tablenames"]))
+
+    logger.info("checking if required database table exists...")
+    try:
+        missing = find_missing_tables(insp, list(tablenames.values()),
+                                      skip_default=True)
+    except Exception as ex:
+        msg = f"{ex}"
+        logger.error(msg)
+        raise RuntimeError(msg)
+    else:
+        if missing:
+            msg = f"table(s) {', '.join(missing)} not found in the database."
+            logger.error(msg)
+            raise RuntimeError(msg)
+
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    logger.info("setting up Backfill...")
+    config = configuration["backfill"]
+
+    # Create Backfill specific configuration. It is initialized with
+    # settings from relevant section of the global configuration, but new
+    # settings may be added, already existing ones may be altered.
+    backfill_config = dict(config)
+
+    backfill_config["session"] = session
+    backfill_config["tablenames"] = tablenames
+
+    logger.info("starting Backfill...")
+    component = Backfill(backfill_config)
+    component.run()

--- a/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
@@ -57,7 +57,7 @@ def backfill():
               help="Validate configuration before starting the service.")
 @click.argument("filename", type=click.Path(exists=True))
 def start(filename, dump, validate):
-    """Starts a finder using a configuration from FILENAME.
+    """Starts a backfill using a configuration from FILENAME.
     """
     with open(filename) as f:
         configuration = yaml.safe_load(f)

--- a/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
@@ -20,23 +20,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Command line interface for the Backfill component.
 """
-import importlib
-import inspect
-import jsonschema
 import logging
 import click
 import yaml
-from sqlalchemy import create_engine, inspect
-from sqlalchemy.orm import sessionmaker
 from .backfill import Backfill
-from .. import validation
-from ..utils import (
-    dump_config,
-    dump_env,
-    setup_logging,
-    find_missing_tables,
-    fully_qualify_tables,
-)
+from ..utils import dump_all, setup_connection, setup_logging, validate_config
+from ..validation import BACKFILL
 
 
 logger = logging.getLogger(__name__)
@@ -62,66 +51,23 @@ def start(filename, dump, validate):
     with open(filename) as f:
         configuration = yaml.safe_load(f)
     if validate:
-        schema = yaml.safe_load(validation.BACKFILL)
-        try:
-            jsonschema.validate(instance=configuration, schema=schema)
-        except jsonschema.ValidationError as ex:
-            msg = f"configuration error: {ex.message}."
-            logger.error(msg)
-            raise ValueError(msg)
-        except jsonschema.SchemaError as ex:
-            msg = f"schema error: {ex.message}."
-            logger.error(msg)
-            raise ValueError(msg)
+        schema = yaml.safe_load(BACKFILL)
+        validate_config(configuration, schema)
         return
 
     config = configuration.get("logging", None)
     setup_logging(options=config)
 
     if dump:
-        msg = "runtime environment and configuration:\n\n"
-        msg += dump_env()
-        msg += "\n"
-        msg += dump_config(configuration)
-        logger.info(msg)
+        logger.info(dump_all(configuration))
 
     logger.info("setting up database connection...")
     config = configuration["database"]
-
-    module = importlib.import_module("sqlalchemy.pool")
-    pool_name = config.get("pool_class", "QueuePool")
     try:
-        class_ = getattr(module, pool_name)
-    except AttributeError:
-        msg = f"unknown connection pool type: {pool_name}"
-        logger.error(msg)
-        raise RuntimeError(msg)
-
-    engine = create_engine(config["engine"],
-                           echo=config.get("echo", False),
-                           poolclass=class_)
-    insp = inspect(engine)
-
-    # Save tablenames for future reference making sure the schema is always
-    # explicitly specified (needed to properly define ORMs later on).
-    tablenames = fully_qualify_tables(insp, dict(config["tablenames"]))
-
-    logger.info("checking if required database table exists...")
-    try:
-        missing = find_missing_tables(insp, list(tablenames.values()),
-                                      skip_default=True)
-    except Exception as ex:
-        msg = f"{ex}"
-        logger.error(msg)
-        raise RuntimeError(msg)
-    else:
-        if missing:
-            msg = f"table(s) {', '.join(missing)} not found in the database."
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-    Session = sessionmaker(bind=engine)
-    session = Session()
+        session, tablenames = setup_connection(config)
+    except RuntimeError as ex:
+        logger.error(ex)
+        raise RuntimeError(ex)
 
     logger.info("setting up Backfill...")
     config = configuration["backfill"]
@@ -130,7 +76,6 @@ def start(filename, dump, validate):
     # settings from relevant section of the global configuration, but new
     # settings may be added, already existing ones may be altered.
     backfill_config = dict(config)
-
     backfill_config["session"] = session
     backfill_config["tablenames"] = tablenames
 

--- a/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/backfill/commands.py
@@ -62,7 +62,7 @@ def start(filename, dump, validate):
     with open(filename) as f:
         configuration = yaml.safe_load(f)
     if validate:
-        schema = yaml.safe_load(validation.finder)
+        schema = yaml.safe_load(validation.backfill)
         try:
             jsonschema.validate(instance=configuration, schema=schema)
         except jsonschema.ValidationError as ex:

--- a/python/lsst/dbb/buffmngrs/endpoint/cli.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/cli.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import click
 import logging
+from .backfill.commands import backfill
 from .finder.commands import finder
 from .ingester.commands import ingester
 
@@ -34,6 +35,7 @@ def cli():
 
 cli.add_command(finder)
 cli.add_command(ingester)
+cli.add_command(backfill)
 
 
 def main():

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/commands.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 @click.group()
 def finder():
-    """A group that all commands controlling Finder are attached to.
+    """Manage file discovery at a specified location.
     """
     pass
 

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/commands.py
@@ -20,11 +20,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Command line interface for the Finder component.
 """
-import click
 import importlib
 import inspect
 import jsonschema
 import logging
+import click
 import yaml
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/commands.py
@@ -62,7 +62,7 @@ def start(filename, dump, validate):
     with open(filename) as f:
         configuration = yaml.safe_load(f)
     if validate:
-        schema = yaml.safe_load(validation.finder)
+        schema = yaml.safe_load(validation.FINDER)
         try:
             jsonschema.validate(instance=configuration, schema=schema)
         except jsonschema.ValidationError as ex:

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/commands.py
@@ -21,22 +21,12 @@
 """Command line interface for the Finder component.
 """
 import importlib
-import inspect
-import jsonschema
 import logging
 import click
 import yaml
-from sqlalchemy import create_engine, inspect
-from sqlalchemy.orm import sessionmaker
 from .finder import Finder
-from .. import validation
-from ..utils import (
-    dump_config,
-    dump_env,
-    setup_logging,
-    find_missing_tables,
-    fully_qualify_tables,
-)
+from ..utils import dump_all, setup_connection, setup_logging, validate_config
+from ..validation import FINDER
 
 
 logger = logging.getLogger(__name__)
@@ -62,66 +52,23 @@ def start(filename, dump, validate):
     with open(filename) as f:
         configuration = yaml.safe_load(f)
     if validate:
-        schema = yaml.safe_load(validation.FINDER)
-        try:
-            jsonschema.validate(instance=configuration, schema=schema)
-        except jsonschema.ValidationError as ex:
-            msg = f"configuration error: {ex.message}."
-            logger.error(msg)
-            raise ValueError(msg)
-        except jsonschema.SchemaError as ex:
-            msg = f"schema error: {ex.message}."
-            logger.error(msg)
-            raise ValueError(msg)
+        schema = yaml.safe_load(FINDER)
+        validate_config(configuration, schema)
         return
 
     config = configuration.get("logging", None)
     setup_logging(options=config)
 
     if dump:
-        msg = "runtime environment and configuration:\n\n"
-        msg += dump_env()
-        msg += "\n"
-        msg += dump_config(configuration)
-        logger.info(msg)
+        logger.info(dump_all(configuration))
 
     logger.info("setting up database connection...")
     config = configuration["database"]
-
-    module = importlib.import_module("sqlalchemy.pool")
-    pool_name = config.get("pool_class", "QueuePool")
     try:
-        class_ = getattr(module, pool_name)
-    except AttributeError:
-        msg = f"unknown connection pool type: {pool_name}"
-        logger.error(msg)
-        raise RuntimeError(msg)
-
-    engine = create_engine(config["engine"],
-                           echo=config.get("echo", False),
-                           poolclass=class_)
-    insp = inspect(engine)
-
-    # Save tablenames for future reference making sure the schema is always
-    # explicitly specified (needed to properly define ORMs later on).
-    tablenames = fully_qualify_tables(insp, dict(config["tablenames"]))
-
-    logger.info("checking if required database table exists...")
-    try:
-        missing = find_missing_tables(insp, list(tablenames.values()),
-                                      skip_default=True)
-    except Exception as ex:
-        msg = f"{ex}"
-        logger.error(msg)
-        raise RuntimeError(msg)
-    else:
-        if missing:
-            msg = f"table(s) {', '.join(missing)} not found in the database."
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-    Session = sessionmaker(bind=engine)
-    session = Session()
+        session, tablenames = setup_connection(config)
+    except RuntimeError as ex:
+        logger.error(ex)
+        raise RuntimeError(ex) from ex
 
     logger.info("setting up Finder...")
     config = configuration["finder"]
@@ -130,7 +77,6 @@ def start(filename, dump, validate):
     # settings from relevant section of the global configuration, but new
     # settings may be added, already existing ones may be altered.
     finder_config = dict(config)
-
     finder_config["session"] = session
     finder_config["tablenames"] = tablenames
 

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
@@ -127,7 +127,7 @@ class Finder:
 
                 action_type = "std"
 
-                logger.debug(f"checking if already tracked")
+                logger.debug("checking if already tracked")
                 try:
                     checksum = get_checksum(abspath)
                 except FileNotFoundError:
@@ -161,7 +161,7 @@ class Finder:
                 if action_type == "alt":
                     continue
 
-                logger.debug(f"updating database entries")
+                logger.debug("updating database entries")
                 dirname, basename = os.path.split(action.path)
                 entry = self.File(
                     relpath=os.path.relpath(dirname, start=self.storage),

--- a/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/finder/finder.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Component responsible for file discovery.
 """
-import hashlib
 import logging
 import os
 import re
@@ -29,6 +28,7 @@ import time
 from datetime import date, datetime, timedelta
 from sqlalchemy.exc import SQLAlchemyError
 from ..declaratives import file_creator
+from ..utils import get_checksum
 
 
 __all__ = ["Finder"]
@@ -186,41 +186,6 @@ class Finder:
 
             logger.debug(f"no new files, next check in {self.pause} sec.")
             time.sleep(self.pause)
-
-
-def get_checksum(path, method='blake2', block_size=4096):
-    """Calculate checksum for a file using BLAKE2 cryptographic hash function.
-
-    Parameters
-    ----------
-    path : `str`
-        Path to the file.
-    method : `str`
-        An algorithm to use for calculating file's hash. Supported algorithms
-        include:
-        * _blake2_: BLAKE2 cryptographic hash,
-        * _md5_: traditional MD5 algorithm,
-        * _sha1_: SHA-1 cryptographic hash.
-        By default or if unsupported method is provided, BLAKE2 algorithm wil
-        be used.
-    block_size : `int`, optional
-        Size of the block
-
-    Returns
-    -------
-    `str`
-        File's hash calculated using a given method.
-    """
-    methods = {
-        'blake2': hashlib.blake2b,
-        'md5': hashlib.md5,
-        'sha1': hashlib.sha1,
-    }
-    hasher = methods.get(method, hashlib.blake2b)()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(block_size), b""):
-            hasher.update(chunk)
-    return hasher.hexdigest()
 
 
 def scan(directory, blacklist=None, **kwargs):

--- a/python/lsst/dbb/buffmngrs/endpoint/ingester/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/ingester/commands.py
@@ -140,5 +140,5 @@ def start(filename, dump, validate):
     ingester_config["plugin"]["class"] = class_
 
     logger.info("starting Ingester...")
-    ingester = Ingester(ingester_config)
-    ingester.run()
+    component = Ingester(ingester_config)
+    component.run()

--- a/python/lsst/dbb/buffmngrs/endpoint/ingester/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/ingester/commands.py
@@ -42,6 +42,8 @@ logger = logging.getLogger(__name__)
 
 @click.group()
 def ingester():
+    """Manage file ingestion to a data management system.
+    """
     pass
 
 

--- a/python/lsst/dbb/buffmngrs/endpoint/ingester/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/ingester/commands.py
@@ -18,11 +18,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import click
 import importlib
 import inspect
 import jsonschema
 import logging
+import click
 import yaml
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker

--- a/python/lsst/dbb/buffmngrs/endpoint/ingester/commands.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/ingester/commands.py
@@ -60,7 +60,7 @@ def start(filename, dump, validate):
     with open(filename) as f:
         configuration = yaml.safe_load(f)
     if validate:
-        schema = yaml.safe_load(validation.ingester)
+        schema = yaml.safe_load(validation.INGESTER)
         try:
             jsonschema.validate(instance=configuration, schema=schema)
         except jsonschema.ValidationError as ex:

--- a/python/lsst/dbb/buffmngrs/endpoint/ingester/ingester.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/ingester/ingester.py
@@ -43,7 +43,7 @@ field_names = ['abspath', 'timestamp', 'duration', 'message', 'version']
 Result = namedtuple('Result', field_names)
 
 
-class Ingester(object):
+class Ingester:
     """Framework managing image ingest process.
 
     Ingester manages the process of ingesting images to different database

--- a/python/lsst/dbb/buffmngrs/endpoint/search.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/search.py
@@ -1,0 +1,213 @@
+# This file is part of dbb_buffmngrs_endpoint.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Methods responsible for file discovery.
+"""
+import logging
+import os
+import re
+from datetime import date, datetime, timedelta
+
+
+__all__ = (
+    "parse_rsync_logs",
+    "scan",
+    "search_methods",
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# A registry of available file discovery methods.
+#
+# The registry is being populated when module is loaded with function
+# decorated with @registry decorator.
+search_methods = {}
+
+
+def register(gen):
+    """Register a generator as a file discovery method.
+
+    Parameters
+    ----------
+    gen : generator
+        A generator iterating over a file names in a given directory tree.
+
+    Returns
+    -------
+    gen : generator
+        The original, unchanged generator.
+    """
+    search_methods[gen.__name__] = gen
+    return gen
+
+
+@register
+def scan(directory, blacklist=None, **kwargs):
+    """Generate the file names in a directory tree.
+
+    Generates the file paths in a given directory tree excluding those files
+    that were blacklisted.
+
+    Parameters
+    ----------
+    directory : `str`
+        The root of the directory tree which need to be searched.
+    blacklist : `list` of `str`, optional
+        List of regular expressions file names should be match against. If a
+        filename matches any of the patterns in the list, file will be ignored.
+        By default, no file is ignored.
+
+    Yields
+    ------
+    path : `string`
+        An file path relative to the ``directory``.
+    """
+    if blacklist is None:
+        blacklist = []
+    for dirpath, _, filenames in os.walk(directory):
+        for fn in filenames:
+            path = os.path.relpath(os.path.join(dirpath, fn), start=directory)
+            if any(re.search(patt, path) for patt in blacklist):
+                continue
+            yield path
+
+
+@register
+def parse_rsync_logs(directory, blacklist=None,
+                     isodate=None, past_days=1, future_days=1,
+                     delay=60, extension="done"):
+    """Generate the file names based on the content of the rsync logs.
+
+    This is a specialized search method for finding files which where
+    transferred to the storage area by ``rsync``. It identifies these
+    files by parsing ``rsync``'s log files. It assumes that:
+
+    1. The logs are stored in a centralized location.
+    2. Logs from different days are kept in different subdirectories in that
+       location.
+    3. The name of each subdirectory represents the date when
+       files where transferred and that date is expressed as ``YYYYMMDD``.
+    4. Log files contain file paths relative to the root of the storage area.
+
+    After the function completed parsing a given logfile, it creates an
+    empty file ``<logfile>.<extension>`` which act as a sentinel preventing it
+    from parsing the file again.
+
+    As the files from a single observation night can be placed in different
+    directories and these directories can be created in a time zone
+    different from the one the endpoint site operates in, be default the
+    function monitors also log files in directories corresponding to a day
+    before and a day after the current day (if any of them exists).  This
+    default settings determining which directories will be monitored can be
+    changed by adjusting ``past_days`` and ``future_days`` options (see
+    below).
+
+    Parameters
+    ----------
+    directory : `str`
+        The directory where the all log files reside.
+    blacklist : `list` of `str`, optional
+        List of regular expressions file names should be match against. If a
+        filename matches any of the patterns in the list, file will be ignored.
+        By default, no file is ignored.
+    isodate : `str`, optional
+        String representing ISO date corresponding the directory which the
+        function should monitor for new logs. If None (default), it will be set
+        to the current date.
+    past_days : `int`, optional
+        The number of past days to add to the list of monitored directories.
+        Defaults to 1.
+    future_days : `int`, optional
+        The number of future days to add to the list of monitored directories.
+        Defaults to 1.
+    delay : `int`, optional
+        Time (in seconds) that need to pass from log's last modification before
+        it will be considered fully transferred. By default, it is 60 s.
+    extension : `str`, optional
+        An extension to use when creating a sentinel file. Defaults to "done".
+
+    Yields
+    ------
+    path : `string`
+        A file path extracted from the log files.
+    """
+    if blacklist is None:
+        blacklist = []
+    delay = timedelta(seconds=delay)
+    origin = date.today()
+    if isodate is not None:
+        origin = date.fromisoformat(isodate)
+    start = origin - timedelta(days=past_days)
+    for offset in range(past_days + future_days + 1):
+        day = start + timedelta(days=offset)
+        top = os.path.join(directory, day.isoformat().replace("-", ""))
+        if not os.path.exists(top):
+            continue
+        for dirpath, _, filenames in os.walk(top):
+            manifests = [os.path.join(dirpath, fn) for fn in filenames
+                         if re.match(r"rsync.*log$", fn)]
+            for manifest in manifests:
+                sentinel = ".".join([manifest, extension])
+
+                # Ignore a log file if it was modified withing a specified
+                # time span, i.e., assume that its transfer has not finished
+                # yet.
+                manifest_mtime = None
+                try:
+                    status = os.stat(manifest)
+                except FileNotFoundError:
+                    logger.error(f"{manifest}: file not found")
+                else:
+                    manifest_mtime = datetime.fromtimestamp(status.st_mtime)
+                now = datetime.now()
+                if manifest_mtime is None or now - manifest_mtime < delay:
+                    continue
+
+                # Check if a log file was already parsed, i.e., a sentinel
+                # file exists. If it wasn't (no sentinel), do nothing; file
+                # hasn't been parsed yet. If it was parsed, check if by
+                # chance the log file hasn't been modified AFTER it was
+                # marked as parsed. It that's the case, remove the sentinel.
+                sentinel_mtime = None
+                try:
+                    status = os.stat(sentinel)
+                except FileNotFoundError:
+                    pass
+                else:
+                    sentinel_mtime = datetime.fromtimestamp(status.st_mtime)
+                if sentinel_mtime is not None:
+                    if sentinel_mtime < manifest_mtime:
+                        logger.error(f"{manifest} changed since marked as "
+                                     f"parsed, removing the sentinel")
+                        os.unlink(sentinel)
+                    else:
+                        continue
+
+                with open(manifest) as f:
+                    for line in f:
+                        if "<f+++++++++" not in line:
+                            continue
+                        _, _, path, *_ = line.strip().split()
+                        if any(re.search(patt, path) for patt in blacklist):
+                            continue
+                        yield path
+                os.mknod(sentinel)

--- a/python/lsst/dbb/buffmngrs/endpoint/search.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/search.py
@@ -26,11 +26,7 @@ import re
 from datetime import date, datetime, timedelta
 
 
-__all__ = (
-    "parse_rsync_logs",
-    "scan",
-    "search_methods",
-)
+__all__ = ["parse_rsync_logs", "scan", "search_methods"]
 
 
 logger = logging.getLogger(__name__)

--- a/python/lsst/dbb/buffmngrs/endpoint/search.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/search.py
@@ -75,6 +75,8 @@ def scan(directory, blacklist=None, **kwargs):
         List of regular expressions file names should be match against. If a
         filename matches any of the patterns in the list, file will be ignored.
         By default, no file is ignored.
+    **kwargs
+        Additional keyword arguments.
 
     Yields
     ------

--- a/python/lsst/dbb/buffmngrs/endpoint/status.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/status.py
@@ -33,3 +33,4 @@ class Status(enum.Enum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
     UNKNOWN = "UNKNOWN"
+    BACKFILL = "BACKFILL"

--- a/python/lsst/dbb/buffmngrs/endpoint/utils.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/utils.py
@@ -24,14 +24,14 @@ import subprocess
 import yaml
 
 
-__all__ = (
+__all__ = [
     "dump_config",
     "dump_env",
     "setup_logging",
     "find_missing_tables",
     "fully_qualify_tables",
     "get_checksum",
-)
+]
 
 
 def setup_logging(options=None):

--- a/python/lsst/dbb/buffmngrs/endpoint/utils.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/utils.py
@@ -152,9 +152,10 @@ def fully_qualify_tables(inspector, specifications):
     ----------
     inspector : `sqlalchemy.engine.reflection.Inspector`
         A proxy object allowing for database inspection.
-    specifications : `list` [ `dict` ]
-        A list of table specifications. Each specification must be a dictionary
-        of the form:
+    specifications : `dict` [ `str', `dict` ]
+        A mapping between object relational mappers (ORMs) and corresponding
+        table specifications. Each specification must be a dictionary of
+        the form:
 
             {
                 "schema": "<schema_name>",

--- a/python/lsst/dbb/buffmngrs/endpoint/validation.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/validation.py
@@ -22,7 +22,7 @@
 """
 
 
-__all__ = ["finder", "ingester"]
+__all__ = ["backfill", "finder", "ingester"]
 
 
 finder = """
@@ -285,4 +285,94 @@ properties:
 required:
     - database
     - ingester
+"""
+
+backfill = """
+---
+type: object
+properties:
+    database:
+        type: object
+        properties:
+            engine:
+                type: string
+            tablenames:
+                type: object
+                properties:
+                    file:
+                        type: object
+                        properties:
+                            schema:
+                                anyOf:
+                                    - type: string
+                                    - type: "null"
+                            table:
+                                type: string
+                        required:
+                            - table
+                    event:
+                        type: object
+                        properties:
+                            schema:
+                                anyOf:
+                                    - type: string
+                                    - type: "null"
+                            table:
+                                type: string
+                        required:
+                            - table
+                required:
+                    - file
+                    - event
+            echo:
+                type: boolean
+            pool_class:
+                type: string
+        required:
+            - engine
+            - tablenames
+    backfill:
+        type: object
+        properties:
+            storage:
+                type: string
+            sources:
+                type: array
+                items:
+                    type: string
+            search:
+                type: object
+                properties:
+                    blacklist:
+                        anyOf:
+                            - type: array
+                              items:
+                                 type: string
+                              uniqueItems: true
+                            - type: "null"
+        required:
+            - storage
+            - sources
+    logging:
+        type: object
+        properties:
+            file:
+                anyOf:
+                    - type: string
+                    - type: "null"
+            format:
+                anyOf:
+                    - type: string
+                    - type: "null"
+            level:
+                type: string
+                enum:
+                    - DEBUG
+                    - INFO
+                    - WARNING
+                    - ERROR
+                    - CRITICAL
+required:
+    - database
+    - backfill
 """

--- a/python/lsst/dbb/buffmngrs/endpoint/validation.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/validation.py
@@ -40,8 +40,12 @@ properties:
                     file:
                         type: object
                         properties:
-                            schema: string
-                            table: string
+                            schema:
+                                anyOf:
+                                    - type: string
+                                    - type: "null"
+                            table:
+                                type: string
                         required:
                             - table
                 required:
@@ -136,16 +140,24 @@ properties:
                 properties:
                     file:
                         type: object
-                        properties
-                            schema: string
-                            table: string
+                        properties:
+                            schema:
+                                anyOf:
+                                    - type: string
+                                    - type: "null"
+                            table:
+                                type: string
                         required:
                             - table
                     event:
                         type: object
-                        properties
-                            schema: string
-                            table: string
+                        properties:
+                            schema:
+                                anyOf:
+                                    - type: string
+                                    - type: "null"
+                            table:
+                                type: string
                         required:
                             - table
                 required:
@@ -163,20 +175,6 @@ properties:
         properties:
             storage:
                 type: string
-            blacklist:
-                anyOf:
-                    - type: array
-                      items:
-                         type: string
-                      uniqueItems: true
-                    - type: "null"
-            whitelist:
-                anyOf:
-                    - type: array
-                      items:
-                         type: string
-                      uniqueItems: true
-                    - type: "null"
             plugin:
                 type: object
                 properties:
@@ -223,13 +221,19 @@ properties:
                                         root:
                                             type: string
                                         config:
-                                            type: object
+                                            anyOf:
+                                                - type: object
+                                                - type: "null"
                                         config_file:
-                                            type: string
+                                            anyOf:
+                                                - type: object
+                                                - type: "null"
                                         ingest_task:
                                             type: string
                                         output_run:
-                                            type: string
+                                            anyOf:
+                                                - type: object
+                                                - type: "null"
                                         transfer:
                                             type: string
                                             enum:
@@ -243,7 +247,6 @@ properties:
                                                 - direct
                                     required:
                                         - root
-                                        - output_run
                 required:
                     - name
                     - config

--- a/python/lsst/dbb/buffmngrs/endpoint/validation.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/validation.py
@@ -22,10 +22,10 @@
 """
 
 
-__all__ = ["backfill", "finder", "ingester"]
+__all__ = ["BACKFILL", "FINDER", "INGESTER"]
 
 
-finder = """
+FINDER = """
 ---
 type: object
 properties:
@@ -126,7 +126,7 @@ required:
     - finder
 """
 
-ingester = """
+INGESTER = """
 ---
 type: object
 properties:
@@ -290,7 +290,7 @@ required:
     - ingester
 """
 
-backfill = """
+BACKFILL = """
 ---
 type: object
 properties:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,96 @@
+# This file is part of dbb_buffmngrs_endpoint.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import jsonschema
+import os
+import unittest
+import yaml
+from lsst.dbb.buffmngrs.endpoint import validation
+
+
+TESTDIR = os.path.dirname(__file__)
+
+
+class FinderConfigValidationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.schema = yaml.safe_load(validation.finder)
+        self.etc = os.path.join(TESTDIR, "../etc")
+
+    def tearDown(self):
+        pass
+
+    def testSampleFile(self):
+        """Test if sample configuration validates under the schema.
+        """
+        with open(os.path.join(self.etc, "finder.yaml")) as f:
+            config = yaml.safe_load(f)
+        jsonschema.validate(config, self.schema)
+
+
+class BackfillConfigValidationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.schema = yaml.safe_load(validation.backfill)
+        self.etc = os.path.join(TESTDIR, "../etc")
+
+    def tearDown(self):
+        pass
+
+    def testSampleFile(self):
+        """Test if sample configuration validates under the schema.
+        """
+        with open(os.path.join(self.etc, "backfill.yaml")) as f:
+            config = yaml.safe_load(f)
+        jsonschema.validate(config, self.schema)
+
+
+class Gen2IngesterConfigValidationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.schema = yaml.safe_load(validation.ingester)
+        self.etc = os.path.join(TESTDIR, "../etc")
+
+    def tearDown(self):
+        pass
+
+    def testSampleFile(self):
+        """Test if sample configuration validates under the schema.
+        """
+        with open(os.path.join(self.etc, "gen2ingester.yaml")) as f:
+            config = yaml.safe_load(f)
+        jsonschema.validate(config, self.schema)
+
+
+class Gen3IngesterConfigValidationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.schema = yaml.safe_load(validation.ingester)
+        self.etc = os.path.join(TESTDIR, "../etc")
+
+    def tearDown(self):
+        pass
+
+    def testSampleFile(self):
+        """Test if sample configuration validates under the schema.
+        """
+        with open(os.path.join(self.etc, "gen3ingester.yaml")) as f:
+            config = yaml.safe_load(f)
+        jsonschema.validate(config, self.schema)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -31,7 +31,7 @@ TESTDIR = os.path.dirname(__file__)
 class FinderConfigValidationTest(unittest.TestCase):
 
     def setUp(self):
-        self.schema = yaml.safe_load(validation.finder)
+        self.schema = yaml.safe_load(validation.FINDER)
         self.etc = os.path.join(TESTDIR, "../etc")
 
     def tearDown(self):
@@ -48,7 +48,7 @@ class FinderConfigValidationTest(unittest.TestCase):
 class BackfillConfigValidationTest(unittest.TestCase):
 
     def setUp(self):
-        self.schema = yaml.safe_load(validation.backfill)
+        self.schema = yaml.safe_load(validation.BACKFILL)
         self.etc = os.path.join(TESTDIR, "../etc")
 
     def tearDown(self):
@@ -65,7 +65,7 @@ class BackfillConfigValidationTest(unittest.TestCase):
 class Gen2IngesterConfigValidationTest(unittest.TestCase):
 
     def setUp(self):
-        self.schema = yaml.safe_load(validation.ingester)
+        self.schema = yaml.safe_load(validation.INGESTER)
         self.etc = os.path.join(TESTDIR, "../etc")
 
     def tearDown(self):
@@ -82,7 +82,7 @@ class Gen2IngesterConfigValidationTest(unittest.TestCase):
 class Gen3IngesterConfigValidationTest(unittest.TestCase):
 
     def setUp(self):
-        self.schema = yaml.safe_load(validation.ingester)
+        self.schema = yaml.safe_load(validation.INGESTER)
         self.etc = os.path.join(TESTDIR, "../etc")
 
     def tearDown(self):


### PR DESCRIPTION
Added a backfill tool allowing one to populate endpoint manager's table with entries related to files which were already in the storage area before its initial deployment.

Note that this tool does *not* check if a file is ingested to the Butler dataset repository managed by the endpoint manager nor it tries to ingest the file if it isn't. It merely makes the endpoint manager "aware of" these files.