### PR TITLE
DM-29429: Change NCSA ingest to use success/fail callbacks

### DIFF
--- a/doc/lsst.dbb.buffmngrs.endpoint/configuration.rst
+++ b/doc/lsst.dbb.buffmngrs.endpoint/configuration.rst
@@ -321,12 +321,23 @@ Event table specification looks exactly like file table specification (see
 ``ingester.plugin.config``
     *Type*: object
 
-    This section contains configuration settigs for a specific ingest code used
-    by the given plugin.  All settings are passed directly to the LSST function
-    responsible for creating the actual ingest task.
+    This section contains configuration settings for a specific ingest code
+    used by the given plugin.
 
-    Only **root**, the absolute path of the Butler dataset repository, is
-    mandatory, others are optional.
+    For Gen2 and Gen3 Butler ingest plugins, the subsection called **butler**
+    must exist and it must contain **root** setting, the absolute path of the
+    Butler dataset repository.  An optional subsection called **ingest** allow
+    for overriding default ingest settings.
+
+    An additional section, called **visit**, may be specified for Gen3 ingest
+    plugin.  If specified, the Gen3 ingest plugin will also invoke the LSST
+    task responsible for defining visits after a successful ingestion.  When
+    specified, the section must contain **instrument**, a fully-qualified class
+    name which handles instrument-specific logic for the Gen3 Butler.
+
+    Example files showing complete list of options recognized by the given
+    plugin as well as their default values are located in project's ``etc``
+    directory.
 
 ``ingester.include_list``
     *Type*: sequence

--- a/doc/lsst.dbb.buffmngrs.endpoint/get-started.rst
+++ b/doc/lsst.dbb.buffmngrs.endpoint/get-started.rst
@@ -106,7 +106,7 @@ information about file, here ``files``.
    example, if the table ``files`` is located in the schema ``dbbbm``,  section
    ``tablenames`` should be specified as:
 
-   .. code-block: yaml
+   .. code-block:: yaml
 
       tablenames:
         schema: dbbbm
@@ -135,7 +135,8 @@ The Ingester configuration looks quite similar:
      plugin:
        name: Gen2Ingest
        config:
-         root: /data/gen2repo
+         butler:
+           root: /data/gen2repo
 
 As you can see, the section ``database`` is identical to the respective
 section of Finder's configuration.
@@ -147,8 +148,8 @@ The Ingester uses plugins to ingest images to different database systems. Hence
 you need to tell which plugin to use and provide settings a given plugin may
 need to access the data management system it supports.
 
-In the provided example the Ingester will be ingesting images to a Gen2 data
-repository located in ``/data/gen2repo``.
+In the provided example the Ingester will be ingesting images to a Gen2 Butler
+dataset repository located in ``/data/gen2repo``.
 
 .. note::
 
@@ -261,6 +262,7 @@ tell the Ingester to make another ingest attempt for selected files.  To do so:
    with ``RERUN`` status (note two new lines at the end):
 
    .. code-block:: YAML
+      :emphasize-lines: 14-15
 
       database:
         engine: "postgres://tester:password@localhost:5432/test"
@@ -273,7 +275,8 @@ tell the Ingester to make another ingest attempt for selected files.  To do so:
         plugin:
           name: Gen2Ingest
           config:
-            root: /data/gen2repo
+            butler:
+              root: /data/gen2repo
         daemon: false
         file_status: RERUN
 

--- a/etc/gen2ingester.yaml
+++ b/etc/gen2ingester.yaml
@@ -13,21 +13,19 @@ ingester:
   storage: <storage area>
   plugin:
     name: Gen2Ingester
-
-    # This section contains settings which are passed directly to the
-    # LSST function responsible for creating the actual ingest task.
     config:
 
-      # Gen2Ingest specific options.
-      #
-      # Note
-      # ----
-      # Only 'root' is required, others are optional.
-      root: <dataset repository>
-      dryrun: false
-      mode: link
-      create: false
-      ignoreIngested: false
+      # Settings specific to accessing the dataset repository.
+      butler:
+        root: <dataset repository>
+
+      # Settings specific to ingesting raw images to the repository.
+      ingest:
+        task: lsst.pipe.tasks.ingest.IngestTask
+        dryrun: false
+        mode: link
+        create: false
+        ignoreIngested: false
 
   include_list: null
   exclude_list: null

--- a/etc/gen3ingester.yaml
+++ b/etc/gen3ingester.yaml
@@ -13,24 +13,27 @@ ingester:
   storage: <storage area>
   plugin:
     name: Gen3Ingest
-
-    # This section contains settings which are passed directly to the
-    # LSST function responsible for creating the actual ingest task.
     config:
 
-      # Gen3Ingest specific options.
-      #
-      # Note
-      # ----
-      # Only 'root' is required, others are optional.
-      root: <dataset repository>
-      config: null
-      config_file: null
-      ingest_task: lsst.obs.base.RawIngestTask
-      output_run: null
-      processes: 1
-      transfer: symlink
-      failFast: true
+      # Settings specific to accessing the dataset repository.
+      butler:
+        root: <dataset repository>
+        collection: null
+
+      # Settings specific to ingesting raw images.
+      ingest:
+        config: null
+        config_file: null
+        processes: 1
+        task: lsst.obs.base.RawIngestTask
+        transfer: symlink
+
+      # Settings specific to defining visits.
+      visit:
+        instrument: <instrument>
+        config_file: null
+        processes: 1
+        task: lsst.obs.base.DefineVisitTask
 
   include_list: null
   exclude_list: null

--- a/python/lsst/dbb/buffmngrs/endpoint/ingester/ingester.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/ingester/ingester.py
@@ -447,11 +447,17 @@ def worker(inp, out, plugin_cls, plugin_cfg):
             status = Status.FAILURE
         except Exception as exc:
             logger.exception(exc)
-            # Find the root cause of the exception as it seems that for both
-            # Gen2 and Gen3 Butler the most meaningful error messages tend
-            # to be located at the very bottom of the stack trace.
+
+            # Find the root cause of the exception to persist it in the
+            # database.
+            #
+            # Only really relevant in case of Gen2 and earlier versions of
+            # Gen3 Butler (before failFast/callbacks were available) as the
+            # most meaningful error messages tend to be located at the very
+            # bottom of the stack trace.
             while exc.__cause__ is not None:
                 exc = exc.__cause__
+
             exc_msg = traceback.format_exception_only(type(exc), exc)[0]
             message = exc_msg.strip()
             status = Status.FAILURE

--- a/python/lsst/dbb/buffmngrs/endpoint/ingester/plugins.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/ingester/plugins.py
@@ -21,15 +21,15 @@
 """Definitions of ingest plugins.
 """
 import logging
-import sys
 
-import lsst.log
-from lsst.daf.butler import Butler
+from lsst.log import UsePythonLogging
+from lsst.daf.butler import Butler, DatasetRef
+from lsst.obs.base.utils import getInstrument
 from lsst.pipe.base.configOverrides import ConfigOverrides
-from lsst.pipe.tasks.ingest import IngestTask
 from lsst.utils import doImport
 
 from ..abcs import Plugin
+from ..utils import get_version
 
 
 __all__ = ["NullIngest", "Gen2Ingest", "Gen3Ingest"]
@@ -47,11 +47,11 @@ class NullIngest(Plugin):
     def __init__(self, config):
         pass
 
-    def version(self):
-        return ""
-
     def execute(self, filename):
         pass
+
+    def version(self):
+        return ""
 
 
 class Gen2Ingest(Plugin):
@@ -72,46 +72,40 @@ class Gen2Ingest(Plugin):
     See ``lsst.pipe.tasks.ingest`` for details.
     """
 
+    defaults = {
+        "create": False,
+        "dryrun": False,
+        "ignoreIngested": False,
+        "mode": "link",
+        "task": "lsst.pipe.tasks.ingest.IngestTask"
+    }
+
     def __init__(self, config):
-        # Set default values for configuration settings, but override
-        # them with the ones provided at runtime, if necessary.
-        self.config = {
-            "dryrun": False,
-            "mode": "link",
-            "create": False,
-            "ignoreIngested": False,
-        }
-        self.config.update(config)
+        try:
+            butler_config = config["butler"]
+        except KeyError:
+            msg = "invalid configuration: Butler settings are missing"
+            logger.error(msg)
+            raise ValueError(msg)
+
+        self.config = {**self.defaults, **butler_config}
+        self.config.update(config.get("ingest", {}))
 
         required = {"root"}
-        missing = required - set(config)
+        missing = required - set(self.config)
         if missing:
             msg = f"Invalid configuration: {', '.join(missing)} not provided."
             logger.error(msg)
             raise ValueError(msg)
 
         # Initialize LSST ingest software.
-        with lsst.log.UsePythonLogging():
-            self.task = IngestTask.prepareTask(**self.config)
+        task_class = doImport(self.config["task"])
+        task_config = {key: val for key, val in self.config.items()
+                       if key != "task"}
+        with UsePythonLogging():
+            self.task = task_class.prepareTask(**task_config)
 
-        # Retrieve the version of the LSST ingest software in use.
-        pkg_name = sys.modules[IngestTask.__module__].__package__
-        pkg = sys.modules[pkg_name]
-        self._version = "N/A"
-        try:
-            self._version = getattr(pkg, "__version__")
-        except AttributeError:
-            logger.warning("failed to identified plugin version")
-
-    def version(self):
-        """Return the version of the LSST ingest task.
-
-        Returns
-        -------
-        `str`
-            Version of the LSST ingest task used for the ingest attempt.
-        """
-        return self._version
+        self._version = get_version(self.config["task"])
 
     def execute(self, path):
         """Make an attempt to ingest the file.
@@ -121,12 +115,126 @@ class Gen2Ingest(Plugin):
         path : `str`
             Path to the file.
         """
-        with lsst.log.UsePythonLogging():
+        with UsePythonLogging():
             self.task.ingestFiles(path)
+
+    def version(self):
+        """Return the version of the LSST ingest task.
+
+        Returns
+        -------
+        ver : `str`
+            Version of the LSST ingest task used for the ingest attempt.
+        """
+        return self._version
 
 
 class Gen3Ingest(Plugin):
     """Ingest a file to Gen3 Butler repository.
+
+    Depending on its configuration, the plugin will also define a visit for
+    the ingested file.
+
+    Parameters
+    ----------
+    config : `dict`
+        Plugin configuration.
+
+    Raises
+    ------
+    ValueError
+        If a required configuration setting is missing.
+    """
+
+    def __init__(self, config):
+        try:
+            butler_config = config["butler"]
+        except KeyError:
+            msg = "invalid configuration: Butler settings are missing"
+            logger.error(msg)
+            raise ValueError(msg)
+
+        self._plugins = []
+
+        # Initialize LSST data access interface.
+        required = {"root"}
+        missing = required - set(butler_config)
+        if missing:
+            msg = f"Invalid configuration: {', '.join(missing)} not provided."
+            logger.error(msg)
+            raise ValueError(msg)
+
+        collection = butler_config.get("collection", None)
+        butler = Butler(butler_config["root"],
+                        collections=collection, writeable=True)
+
+        # Configure and register the LSST task responsible for ingesting raws.
+        task_config = config.get("ingest", {})
+        if collection is not None:
+            task_config["output_run"] = collection
+        self.register(Gen3RawIngestPlugin(task_config, butler))
+
+        # Optionally, configure and register the LSST task responsible for
+        # defining visits.
+        task_config = config.get("visit", {})
+        if task_config:
+            if "instrument" not in task_config:
+                msg = "invalid configuration: instrument not specified"
+                logger.error(msg)
+                raise ValueError(msg)
+            if collection is not None:
+                task_config["collections"] = collection
+            self.register(Gen3DefineVisitsPlugin(task_config, butler))
+
+        self._version = self._plugins[0].version()
+        self._results = None
+
+    def execute(self, data):
+        """Execute the plugins in the sequence.
+
+        The plugins are executed in the order they were registered.
+
+        Parameters
+        ----------
+        data : Any
+            The input data required by the first plugin in the sequence.
+        """
+        for plugin in self._plugins:
+            data = plugin.execute(data)
+
+    def register(self, plugin):
+        """Add an operation to the sequence.
+
+        Parameters
+        ----------
+        plugin : Plugin
+            A plugin
+
+        Raises
+        ------
+        ValueError
+            If the input argument is not a Plugin class instance.
+        """
+        if not isinstance(plugin, Plugin):
+            msg = f"{plugin} is not a 'Plugin' instance"
+            logger.error(msg)
+            raise TypeError(msg)
+        self._plugins.append(plugin)
+
+    def version(self):
+        """Retrieve the version of the LSST software in use.
+
+        Returns
+        -------
+        `str`
+            Version of the LSST software in use.  More specifically,
+            the version of the first LSST task in the sequence.
+        """
+        return self._version
+
+
+class Gen3RawIngestPlugin(Plugin):
+    """Plugin responsible for ingesting images to a Gen3 Butler repository.
 
     The LSST Gen3 Middleware supports parallel ingestion of multiple files.
     However, it does not expose information which files were ingested
@@ -137,12 +245,9 @@ class Gen3Ingest(Plugin):
     Parameters
     ----------
     config : `dict`
-        Plugin configuration.
-
-    Raises
-    ------
-    ValueError
-        If root directory of the Butler repository is not provided.
+        Configuration of the plugin.
+    butler : `lsst.daf.butler.Butler`
+        LSST data access interface.
 
     Notes
     -----
@@ -150,87 +255,73 @@ class Gen3Ingest(Plugin):
     `script/ingestRaws.py`` from ``lsst.obs.base`` package.
     """
 
-    def __init__(self, config):
-        # Set default values for configuration settings, but override their
-        # them with the ones provided at runtime, if necessary.
-        #
-        # As parallel ingestion is disabled, ``processes`` setting will be
-        # ignored and is included only for sake of completeness.
-        self.config = {
-            "config": None,
-            "config_file": None,
-            "ingest_task": "lsst.obs.base.RawIngestTask",
-            "output_run": None,
-            "processes": 1,
-            "transfer": "symlink",
-            "failFast": True,
-        }
-        self.config.update(config)
+    # Default values for configuration settings.
+    #
+    # Parallel ingestion is disabled, ``pool`` and ``processes`` settings
+    # will be ignored and are included only for sake of completeness.
+    defaults = {
+        "config": None,
+        "config_file": None,
+        "output_run": None,
+        "pool": None,
+        "processes": 1,
+        "task": "lsst.obs.base.RawIngestTask",
+        "transfer": "symlink",
+    }
 
-        required = {"root"}
-        missing = required - set(self.config)
-        if missing:
-            msg = f"invalid configuration: {', '.join(missing)} not provided"
-            logger.error(msg)
-            raise ValueError(msg)
+    def __init__(self, config, butler):
+        self.config = {**self.defaults, **config}
 
-        # Initialize LSST ingest software.
-        butler = Butler(self.config["root"], writeable=True)
-        ingest_class = doImport(self.config["ingest_task"])
-        ingest_config = ingest_class.ConfigClass()
-        ingest_config.transfer = self.config["transfer"]
+        task_class = doImport(self.config["task"])
 
-        # TODO: A temporary hack to make the plugin usable with LSST stack
-        #  prior to w_2021_05. Remove the if statement once a the
-        #  pre-failFast stack versions are old enough to never be used again
-        if self.config["failFast"] is not None:
-            ingest_config.failFast = self.config["failFast"]
+        task_config = task_class.ConfigClass()
+        task_config.transfer = self.config["transfer"]
 
-        ingest_config_overrides = ConfigOverrides()
+        task_config_overrides = ConfigOverrides()
         if self.config["config_file"] is not None:
-            ingest_config_overrides.addFileOverride(self.config["config_file"])
+            task_config_overrides.addFileOverride(self.config["config_file"])
         if self.config["config"] is not None:
             for key, val in self.config["config"].items():
-                ingest_config_overrides.addValueOverride(key, val)
-        ingest_config_overrides.applyTo(ingest_config)
-        self.task = ingest_class(config=ingest_config,
-                                 butler=butler,
-                                 on_success=self._handle_success,
-                                 on_metadata_failure=self._handle_failure,
-                                 on_ingest_failure=self._handle_failure)
+                task_config_overrides.addValueOverride(key, val)
+        task_config_overrides.applyTo(task_config)
+        self.task = task_class(config=task_config,
+                               butler=butler,
+                               on_success=self._handle_success,
+                               on_metadata_failure=self._handle_failure,
+                               on_ingest_failure=self._handle_failure)
 
-        # Retrieve the version of the LSST ingest software in use.
-        self._version = "N/A"
-        pkg_name = ".".join(self.config["ingest_task"].split(".")[:-1])
-        pkg = sys.modules[pkg_name]
-        try:
-            self._version = getattr(pkg, "__version__")
-        except AttributeError:
-            logger.warning("failed to identified plugin version")
+        self._version = get_version(self.config["task"])
+        self._result = None
 
-        self._results = None
-
-    def version(self):
-        """Return the version of the LSST ingest task.
-
-        Returns
-        -------
-        `str`
-            Version of the LSST ingest task used for the ingest attempt.
-        """
-        return self._version
-
-    def execute(self, filename):
-        """Make an attempt to ingest the file.
+    def execute(self, path):
+        """Ingest a file to a Gen3 Butler dataset repository.
 
         Parameters
         ----------
-        filename : `str`
+        path : `str`
             Path to the file.
+
+        Returns
+        -------
+        result : `list` [`lsst.daf.bulter.DatasetRef`]
+            Dataset references for ingested raws.
         """
-        with lsst.log.UsePythonLogging():
-            self.task.run([filename],
-                          run=self.config["output_run"], processes=1)
+        data = [path]
+        with UsePythonLogging():
+            result = self.task.run(data,
+                                   run=self.config["output_run"],
+                                   pool=None, processes=1)
+        return result
+
+    def version(self):
+        """Retrieve the version of the LSST task used for ingesting raws.
+
+        Returns
+        -------
+        version : `str`
+            Version of the LSST ingest task responsible for ingesting raws.
+        """
+        return self._version
 
     def _handle_success(self, data):
         """Extract data about the file which was successfully ingested.
@@ -259,3 +350,79 @@ class Gen3Ingest(Plugin):
         """
         self._result = data
         raise exc
+
+
+class Gen3DefineVisitsPlugin(Plugin):
+    """Plugin responsible for defining visits in Gen3 Butler repository.
+
+    Parameters
+    ----------
+    config : `dict`
+        Configuration of the plugin.
+    butler : `lsst.daf.butler.Butler`
+        LSST data access interface.
+
+    Notes
+    -----
+    The code below is essentially a customized version of
+    `script/defineVisits.py`` from ``lsst.obs.base`` package.
+    """
+
+    # Default values for configuration settings.
+    #
+    # The ``pool`` and ``processes`` settings will be ignored and are included
+    # only for sake of completeness.
+    defaults = {
+        "config_file": None,
+        "collections": None,
+        "pool": None,
+        "processes": 1,
+        "task": "lsst.obs.base.DefineVisitsTask"
+    }
+
+    def __init__(self, config, butler):
+        self.config = {**self.defaults, **config}
+
+        task_class = doImport(self.config["task"])
+        task_config = task_class.ConfigClass()
+
+        instr = getInstrument(self.config["instrument"], butler.registry)
+        instr.applyConfigOverrides(task_class._DefaultName, task_config)
+        if self.config["collections"] is None:
+            self.config["collections"] = instr.makeDefaultRawIngestRunName()
+
+        if self.config["config_file"] is not None:
+            task_config.load(self.config["config_file"])
+        self.task = task_class(config=task_config, butler=butler)
+
+        self._version = get_version(self.config["task"])
+
+    def execute(self, refs):
+        """Add visit definition to the registry for the given exposure.
+
+        Parameters
+        ----------
+        refs : `list` [`lsst.daf.butler.DatasetRef`]
+            DataIds of the file for which the visit needs to be defined.
+
+        Returns
+        -------
+        refs : `list` [`lsst.daf.butler.DatasetRef`]
+            The references to the datasets it received.
+        """
+        data = [ref.dataId for ref in refs]
+        with UsePythonLogging():
+            self.task.run(data,
+                          collections=self.config["collections"],
+                          pool=None, processes=1)
+        return refs
+
+    def version(self):
+        """Retrieve the version of the LSST task used for defining visits.
+
+        Returns
+        -------
+        ver : `str`
+            Version of the LSST task responsible for defining visits.
+        """
+        return self._version

--- a/python/lsst/dbb/buffmngrs/endpoint/utils.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/utils.py
@@ -25,6 +25,7 @@ import hashlib
 import importlib
 import logging
 import subprocess
+import sys
 from pathlib import Path
 
 import jsonschema
@@ -41,6 +42,7 @@ __all__ = [
     "fully_qualify_tables",
     "get_checksum",
     "get_file_attributes",
+    "get_version",
     "setup_connection",
     "setup_logging",
     "validate_config",
@@ -230,6 +232,30 @@ def get_checksum(path, method='blake2', block_size=4096):
         for chunk in iter(lambda: f.read(block_size), b""):
             hasher.update(chunk)
     return hasher.hexdigest()
+
+
+def get_version(task):
+    """Retrieve the version of the LSST task.
+
+    Parameters
+    ----------
+    task : `str`
+        Fully-qualified name of the LSST task.
+
+    Returns
+    -------
+    version : `str`
+        String representing the version of the LSST task or ``None`` if the
+        version could not be determined.
+    """
+    mod_name = ".".join(task.split(".")[:-1])
+    pkg_name = sys.modules[mod_name].__package__
+    pkg = sys.modules[pkg_name]
+    try:
+        version = getattr(pkg, "__version__")
+    except AttributeError:
+        return None
+    return version
 
 
 def get_file_attributes(path, checksum=True, start=None):

--- a/python/lsst/dbb/buffmngrs/endpoint/validation.py
+++ b/python/lsst/dbb/buffmngrs/endpoint/validation.py
@@ -192,23 +192,33 @@ properties:
                                 config:
                                     type: object
                                     properties:
-                                        root:
-                                            type: string
-                                        mode:
-                                            type: string
-                                            enum:
-                                                - copy
-                                                - link
-                                                - move
-                                                - skip
-                                        create:
-                                            type: boolean
-                                        dryrun:
-                                            type: boolean
-                                        ignoreIngested:
-                                            type: boolean
+                                        butler:
+                                            type: object
+                                            properties:
+                                                root:
+                                                    type: string
+                                            required:
+                                                - root
+                                        ingest:
+                                            type: object
+                                            properties:
+                                                create:
+                                                    type: boolean
+                                                dryrun:
+                                                    type: boolean
+                                                ignoreIngested:
+                                                    type: boolean
+                                                mode:
+                                                    type: string
+                                                    enum:
+                                                        - copy
+                                                        - link
+                                                        - move
+                                                        - skip
+                                                task:
+                                                    type: string
                                     required:
-                                        - root
+                                        - butler
                     -
                         if: 
                             properties:
@@ -219,37 +229,63 @@ properties:
                                 config:
                                     type: object
                                     properties:
-                                        root:
-                                            type: string
-                                        config:
-                                            anyOf:
-                                                - type: object
-                                                - type: "null"
-                                        config_file:
-                                            anyOf:
-                                                - type: string
-                                                - type: "null"
-                                        ingest_task:
-                                            type: string
-                                        output_run:
-                                            anyOf:
-                                                - type: string
-                                                - type: "null"
-                                        transfer:
-                                            type: string
-                                            enum:
-                                                - auto
-                                                - link
-                                                - symlink
-                                                - hardlink
-                                                - copy
-                                                - move
-                                                - relsymlink
-                                                - direct
-                                        failFast:
-                                            type: boolean
+                                        butler:
+                                            type: object
+                                            properties:
+                                                root:
+                                                    type: string
+                                                collection:
+                                                    anyOf:
+                                                        - type: string
+                                                        - type: "null"
+                                            required:
+                                                - root
+                                        ingest:
+                                            type: object
+                                            properties:
+                                                config:
+                                                    anyOf:
+                                                        - type: object
+                                                        - type: "null"
+                                                config_file:
+                                                    anyOf:
+                                                        - type: string
+                                                        - type: "null"
+                                                processes:
+                                                    type: integer
+                                                    minimum: 1
+                                                transfer:
+                                                    type: string
+                                                    enum:
+                                                        - auto
+                                                        - link
+                                                        - symlink
+                                                        - hardlink
+                                                        - copy
+                                                        - move
+                                                        - relsymlink
+                                                        - direct
+                                                task:
+                                                    type: string
+                                        visit:
+                                            type: object
+                                            properties:
+                                                config_file:
+                                                    anyOf:
+                                                        - type: string
+                                                        - type: "null"
+                                                instrument:
+                                                    type: string
+                                                processes:
+                                                    type: integer
+                                                    minimum: 1
+                                                task:
+                                                    type: string
+                                            required:
+                                                - instrument
                                     required:
-                                        - root
+                                        - butler
+                                        - ingest
                 required:
                     - name
                     - config


### PR DESCRIPTION
The changes also include allowing the manager to define visits after for successful Gen3 ingestions.